### PR TITLE
Ensure NTOKENS is correct with trailing spaces

### DIFF
--- a/JSON.awk
+++ b/JSON.awk
@@ -351,8 +351,8 @@ function tokenize(a1) { #{{{1
 
 	gsub(/^\357\273\277|"[^"\\\000-\037]*((\\[^u\000-\037]|\\u[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])[^"\\\000-\037]*)*"|-?(0|[1-9][0-9]*)([.][0-9]+)?([eE][+-]?[0-9]+)?|null|false|true|[ \t\n\r]+|./, "\n&", a1)
 	gsub("\n" "[ \t\n\r]+", "\n", a1)
-	# ^\n BOM?
-	sub(/^\n(\357\273\277\n)?/, "", a1)
+	# ^\n BOM or \n$?
+	gsub(/^\n(\357\273\277\n)?|\n$/, "", a1)
 	ITOKENS=0 # get_token() helper
 	return NTOKENS = split(a1, TOKENS, /\n/)
 }


### PR DESCRIPTION
I came across an issue in mohd-akram/jawk#2 where trailing spaces caused `NTOKENS` to be incorrect (i.e. 1 greater than it should be). This caused a bug in my patched version of JSON.awk which tokenizes line-by-line, but I figured it was worth upstreaming to ensure correctness.